### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-tf-nightly-gpu
+tensorflow-gpu
 pytest
 networkx
 toposort


### PR DESCRIPTION
now that TF is stable on 1.8.0, could the requirements move from tf-nightly-gpu to main tensorflow-gpu package?