### PR TITLE
handle sparse gradients

### DIFF
--- a/memory_saving_gradients.py
+++ b/memory_saving_gradients.py
@@ -272,15 +272,24 @@ def gradients(ys, xs, grad_ys=None, checkpoints='collection', **kwargs):
                     d_checkpoints[r] = dr
                 else:
                     d_checkpoints[r] += dr
+        def _unsparsify(x):
+            if not isinstance(x, tf.IndexedSlices):
+                return x
+            assert x.dense_shape is not None, "memory_saving_gradients encountered sparse gradients of unknown shape"
+            indices = x.indices
+            while indices.shape.ndims < x.values.shape.ndims:
+                indices = tf.expand_dims(indices, -1)
+            return tf.scatter_nd(indices, x.values, x.dense_shape)
 
         # partial derivatives to xs (usually the params of the neural net)
         d_xs_new = dv[len(checkpoints_other):]
         for j in range(len(xs)):
             if d_xs_new[j] is not None:
                 if d_xs[j] is None:
-                    d_xs[j] = d_xs_new[j]
+                    d_xs[j] = _unsparsify(d_xs_new[j])
                 else:
-                    d_xs[j] += d_xs_new[j]
+                    d_xs[j] += _unsparsify(d_xs_new[j])
+
 
     return d_xs
 


### PR DESCRIPTION
This small fix allows using gradient checkpointing even if some gradients are sparse.

For instance, if one uses Embedding layer and requests derivatives w.r.t. embedding weights, tensorflow.gradients would produce gradient as IndexedSlices instead of tensor.

Doing the same with gradient checkpointing results in an error on line
```
d_xs[j] += d_xs_new[j]
```
Here, both d_xs[j] += d_xs_new[j] would be tf.IndexedSlices that cannot be added with '+'.
A cheap solution is to manually cast everything to dense gradients if addition is required.

Given enough time, one could also devise a way to add indexed slices sparsely. Alas, i am not given enough time.
